### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ["8.10", "9.0", "9.2", "9.4", "9.6"]
+        ghc: ["8.10", "9.0", "9.2", "9.4", "9.6", "9.8"]
     steps:
       - uses: actions/checkout@v4
       - name: "Setup haskell"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,29 +12,29 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ["8.10.7", "9.0.2", "9.2.5", "9.4.4", "9.6.1"]
-    env:
-      CONFIG: "--enable-tests"
+        ghc: ["8.10", "9.0", "9.2", "9.4", "9.6"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: "Setup haskell"
-        uses: haskell/actions/setup@v2
+        uses: haskell-actions/setup@v2
         id: setup-haskell
         with:
           ghc-version: ${{ matrix.ghc }}
-          cabal-version: 3.8.1.0
-      - run: cabal update
-      - run: cabal freeze $CONFIG
-      - uses: actions/cache@v2
+          cabal-version: latest
+          cabal-update:  true
+      - run: |
+          cabal configure --enable-tests --disable-documentation
+          cabal build --dry-run
+        # The latter generates dist-newstyle/cache/plan.json which serves as cache key.
+      - uses: actions/cache@v3
         with:
           path: ${{ steps.setup-haskell.outputs.cabal-store }}
-          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+          key:  ${{ runner.os }}-${{ steps.setup-haskell.outputs.ghc-version }}-${{ hashFiles('dist-newstyle/cache/plan.json') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
-            ${{ runner.os }}-${{ matrix.ghc }}-
-      - run: cabal build $CONFIG
-      - run: cabal test $CONFIG
-      - run: cabal haddock $CONFIG
+                ${{ runner.os }}-${{ steps.setup-haskell.outputs.ghc-version }}-
+      - run: cabal build
+      - run: cabal test
+      - run: cabal haddock
       - run: cabal sdist
 
   check-changelogs:
@@ -48,7 +48,7 @@ jobs:
     - name: Install dependencies
       run: sudo apt install -y fd-find
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: git fetch
       run: git fetch origin master:master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## next version
 
-* `NoThunks ThreadId` instance
+* `NoThunks ThreadId` instance.
+* Fix tests on ghc 9.8.
+  Andreas Abel <andreas.abel@gu.se>
+* Tested with ghc 8.10 to 9.8.
 
 ## 0.1.4 -- 2023-03-27
 

--- a/cabal.project
+++ b/cabal.project
@@ -4,7 +4,3 @@ package nothunks
   tests: True
 
 test-show-details: direct
-
--- TODO: remove once hedgehog is compatible with ghc-9.6
-if impl(ghc >= 9.6)
-  allow-newer: hedgehog:template-haskell

--- a/nothunks.cabal
+++ b/nothunks.cabal
@@ -49,9 +49,9 @@ library
                     , ghc-heap
 
     if flag(bytestring)
-      build-depends:  bytestring >= 0.10 && < 0.12
+      build-depends:  bytestring >= 0.10 && < 0.13
     if flag(text)
-      build-depends:  text       >= 1.2  && < 1.3 || >= 2 && < 2.1
+      build-depends:  text       >= 1.2  && < 1.3 || >= 2 && < 2.2
     if flag(vector)
       build-depends:  vector     >= 0.12 && < 0.14
 
@@ -77,9 +77,9 @@ test-suite nothunks-test
                     , ghc-prim
 
                       -- Additional dependencies
-                    , hedgehog       >= 1.1 && < 1.3
+                    , hedgehog       >= 1.1 && < 1.5
                     , random         >= 1.1 && < 1.3
-                    , tasty          >= 1.3 && < 1.5
+                    , tasty          >= 1.3 && < 1.6
                     , tasty-hedgehog >= 1.1 && < 1.5
 
     hs-source-dirs:   test

--- a/test/Test/NoThunks/Class.hs
+++ b/test/Test/NoThunks/Class.hs
@@ -213,7 +213,11 @@ instance (FromModel a, FromModel b) => FromModel (a, b) where
       PairThunk _     -> NotWHNF ctxt'
       PairDefined a b -> constrNF [modelIsNF ctxt' a, modelIsNF ctxt' b]
     where
+#if MIN_VERSION_GLASGOW_HASKELL(9,8,0,0)
+      ctxt' = "Tuple2" : ctxt
+#else
       ctxt' = "(,)" : ctxt
+#endif
 
   fromModel (PairThunk p)     k = fromModel p $ \p' -> k (if ack 3 3 > 0 then p' else p')
   fromModel (PairDefined a b) k = fromModel a $ \a' ->


### PR DESCRIPTION
- Make full use of haskell-actions/setup,
  like picking the latest GHC minor version for you.
  Also, it already does a `cabal update`.

- Use `cabal configure` to fix the configuration.

- Freeze file isn't a good cache key as it contains a time stamp.
  Use the build plan (`plan.json`) instead.

- Bump actions to their latest version.

- Cache: `restore-keys` automatically includes `key`